### PR TITLE
Implement Aadhar/PAN validation

### DIFF
--- a/payroll_system/db.py
+++ b/payroll_system/db.py
@@ -158,7 +158,18 @@ def add_employee(session, **kwargs):
     str
         The generated ``employee_id``.
     """
-    sensitive_fields = ['aadhar_number', 'pan_number']
+    # Basic validation for government IDs
+    aadhar = kwargs.get("aadhar_number")
+    if aadhar:
+        if not (aadhar.isdigit() and len(aadhar) == 12):
+            raise ValueError("Aadhar number must be a 12-digit number")
+
+    pan = kwargs.get("pan_number")
+    if pan:
+        if len(pan) != 10:
+            raise ValueError("PAN number must be a 10-character code")
+
+    sensitive_fields = ["aadhar_number", "pan_number"]
     for field in sensitive_fields:
         if field in kwargs and kwargs[field]:
             kwargs[field] = encrypt(kwargs[field])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,43 @@
 import sys
+import os
 from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("PAYROLL_DB", ":memory:")
 
+import pytest
 from payroll_system.ml_utils import predict_bonus_eligibility
+from payroll_system.db import init_db, get_session, add_employee
 
 
 def test_bonus_eligibility():
     assert predict_bonus_eligibility(300, 0, 2) is True
     assert predict_bonus_eligibility(250, 0, 2) is False
+
+
+def test_add_employee_validation():
+    init_db()
+    session = get_session()
+
+    emp_id = add_employee(
+        session,
+        name="John",
+        aadhar_number="123456789012",
+        pan_number="ABCDE1234F",
+    )
+    assert emp_id
+
+    with pytest.raises(ValueError):
+        add_employee(
+            session,
+            name="Jane",
+            aadhar_number="12345",
+            pan_number="ABCDE1234F",
+        )
+
+    with pytest.raises(ValueError):
+        add_employee(
+            session,
+            name="Jim",
+            aadhar_number="123456789012",
+            pan_number="ABCDE123",
+        )


### PR DESCRIPTION
## Summary
- validate Aadhar and PAN numbers in `add_employee`
- test for new validation logic

## Testing
- `pip install scikit-learn`
- `pip install cryptography`
- `pip install SQLAlchemy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68588c4225e48326a64b74c01fc57f7c